### PR TITLE
Update EBB 42 CAN.md

### DIFF
--- a/docs/EBB 42 CAN.md
+++ b/docs/EBB 42 CAN.md
@@ -105,7 +105,7 @@ Version:V1.1
 	<tr>
     <td>0N</td><td>0N</td><td>0N</td><td>OFF</td><td>Two Lines PT100</td></tr>
 	<tr>
-    <td>0N</td><td>0N</td><td>OFF<td>OFF</td><td>Two Lines PT1000</td></tr>
+    <td>0N</td><td>0N</td><td>OFF<td>ON</td><td>Two Lines PT1000</td></tr>
     <tr>
     <td>OFF</td><td>OFF</td><td>0N</td><td>OFF</td><td>Four Lines PT100</td></tr>
     <tr>


### PR DESCRIPTION
Fixed error on dip switch selector for 2 wire PT1000 (ON ON OFF ON instead of ON ON OFF OFF)