### PR TITLE
fix(panda-breath): printable files link points to Panda Turbo files

### DIFF
--- a/docs/Panda_Breath.md
+++ b/docs/Panda_Breath.md
@@ -3,7 +3,7 @@
 <img src=img/PandaBreath/image.jpg width="600"/>
 
 - **Product Link**: [Buy Here](https://biqu.equipment/products/biqu-panda-breath-smart-air-filtration-and-heating-system-with-precise-temperature-regulation?_pos=1&_sid=3a4ce2d06&_ss=r&variant=42353406279778) 
-- **Print files are available on**: [GitHub](https://github.com/bigtreetech/Panda-Turbo-Kit/tree/master/3D%20Model)
+- **Print files are available on**: [GitHub](https://github.com/bigtreetech/Panda_Breath/tree/master/3D%20Model/Mounting%20solution)
 - **Github**： https://github.com/bigtreetech/Panda_Breath
 
 ## Revision Log


### PR DESCRIPTION
The Panda Breath "Printable Files" link points to the Panda Turbo Kit repository. I fixed it to actually point to the Panda Breath files.