### PR TITLE
docs: add page move

### DIFF
--- a/docs/CB1.md
+++ b/docs/CB1.md
@@ -1,5 +1,11 @@
 # CB1
 
+!!! info "Bigtreetech WiKi NEO"
+    This page has been migrated to the Bigtreetech WiKi NEO
+
+    [Bigtreetech WiKi NEO](https://neo.bttwiki.com/en/docs/board-docs/iot-series/iot-cb1/)
+
+
 [<img src=img/CB1.webp width="500" />](https://bigtreetech.github.io/docs/CB1.html)
 
 ## **Product Profile**

--- a/docs/CB2.md
+++ b/docs/CB2.md
@@ -1,5 +1,10 @@
 # CB2
 
+!!! info "Bigtreetech WiKi NEO"
+    This page has been migrated to the Bigtreetech WiKi NEO
+
+    [Bigtreetech WiKi NEO](https://neo.bttwiki.com/en/docs/board-docs/iot-series/iot-cb2/)
+
 <img src=img/CB2/CB2_Title.webp width="500" />
 
 ## **Product Profile**

--- a/docs/EBB 36 CAN.md
+++ b/docs/EBB 36 CAN.md
@@ -1,5 +1,11 @@
 # EBB 36 CAN
 
+!!! info "Bigtreetech WiKi NEO"
+    This page has been migrated to the Bigtreetech WiKi NEO
+
+    [Bigtreetech WiKi NEO](https://neo.bttwiki.com/en/docs/board-docs/ebb-series/ebb-36/)
+
+
 <img src=img/EBB36CAN/EBB_36_Title.webp width="550">  
 
 ## Product Profile

--- a/docs/_biqumkdocs/mkdocs.yml
+++ b/docs/_biqumkdocs/mkdocs.yml
@@ -330,5 +330,41 @@ nav:
     - Cooling solution:
       - Universal Turbo Kit.md 
       - Eco Turbo Kit.md 
+  - Product in wiki NEO:
+    - page_move.md
+    - build palte: https://neo.bttwiki.com/docs/category/build-plate
+    - Board and IOT:
+      - MMB CAN V1.0: https://neo.bttwiki.com/docs/board-docs/mmb-series/mmb-1/
+      - MMB CAN V2.0: https://neo.bttwiki.com/docs/board-docs/mmb-series/mmb-2/
+      - CB1: https://neo.bttwiki.com/docs/board-docs/iot-series/iot-cb1/
+      - CB2: https://neo.bttwiki.com/docs/board-docs/iot-series/iot-cb2/
+      - K HUB: https://neo.bttwiki.com/docs/board-docs/iot-series/iot-khub-v1/
+      - BIGTREETECH Pad5 V2: https://neo.bttwiki.com/docs/board-docs/iot-series/iot-pad5-v2/
+    - Panda series:
+      - Panda Claw A1/A1 Mini: https://neo.bttwiki.com/docs/panda-series/extruder/panda-claw-a1mini/
+      - Panda Claw P1/X1: https://neo.bttwiki.com/docs/panda-series/extruder/panda-claw-px/
+      - Panda Extruder: https://neo.bttwiki.com/docs/panda-series/extruder/panda-extruder/
+      - Panda Revo: https://neo.bttwiki.com/docs/category/panda-revo
+      - Panda Den Air: https://neo.bttwiki.com/docs/panda-series/module/panda-den-air/
+      - Panda Den H2: https://neo.bttwiki.com/docs/panda-series/module/panda-den-h2/
+      - Panda Hotend Wizard: https://neo.bttwiki.com/docs/panda-series/module/panda-hotend-wizard/
+      - Panda Status P2: https://neo.bttwiki.com/docs/panda-series/module/panda-status-p2/
+      - Panda Tap: https://neo.bttwiki.com/docs/panda-series/module/panda-tap/
+      - Panda Vent: https://neo.bttwiki.com/docs/panda-series/module/panda-vent/
+      - BMCU-370: https://neo.bttwiki.com/docs/panda-series/module/bmcu370/
+      - Panda Alarm: https://neo.bttwiki.com/docs/panda-series/module/panda-alarm/
+      - Panda Bamboo Feeder: https://neo.bttwiki.com/docs/panda-series/module/panda-bamboo-feeder/
+      - Panda Branch: https://neo.bttwiki.com/docs/panda-series/module/panda-branch/
+      - Panda Breeze: https://neo.bttwiki.com/docs/panda-series/module/panda-breeze/
+      - Panda Hub: https://neo.bttwiki.com/docs/panda-series/module/panda-hub/
+      - Panda Jet: https://neo.bttwiki.com/docs/panda-series/module/panda-jet/
+      - Panda Jetpack: https://neo.bttwiki.com/docs/panda-series/module/panda-jetpack/
+      - Panda Lux: https://neo.bttwiki.com/docs/panda-series/module/panda-lux/
+      - Panda Treat: https://neo.bttwiki.com/docs/panda-series/module/panda-treat/
+      - Panda Touch: https://neo.bttwiki.com/docs/panda-series/panda-touch/
+    - Pop Series:
+      - PopCap: https://neo.bttwiki.com/docs/more-series/pop-module/pop-cap/
+      - PopStatus: https://neo.bttwiki.com/docs/more-series/pop-module/popstatus/
+    - filament: https://neo.bttwiki.com/docs/filament
   
 copyright: © 2025 必趣创新科技(深圳)有限公司 版权所有 | <a href="https://beian.miit.gov.cn/" target="_blank">粤ICP备2024178516号</a>

--- a/docs/locales/zh_Hans/page_move.md
+++ b/docs/locales/zh_Hans/page_move.md
@@ -1,0 +1,5 @@
+# 页面已迁移至 Bigtreetech Wiki NEO
+
+这些页面已迁移至 Bigtreetech Wiki NEO
+
+本 Wiki 的侧边栏仅包含链接。这会定向到 Bigtreetech Wiki NEO 对应的页面。

--- a/docs/page_move.md
+++ b/docs/page_move.md
@@ -1,0 +1,5 @@
+# page move to Bigtreetech wiki NEO
+
+These pages have been migrated to the Bigtreetech Wiki NEO
+
+This wiki's sidebar contains only links. It can redirect to the corresponding page on the new wiki.


### PR DESCRIPTION
this PR add page move to neo wiki. It add link to `Product in wiki NEO` sidebar.